### PR TITLE
ANSI escape code 文字を考慮して出力するtoStringZを追加

### DIFF
--- a/char-canvas/char-canvas.js
+++ b/char-canvas/char-canvas.js
@@ -64,6 +64,16 @@
 		return t;
 	};
 
+	// # ANSI escape code 文字を考慮した文字列化
+	// @return 文字列化した文字キャンバス。
+	CharCanvas.prototype.toStringZ = function() {
+		var chunks = [];
+		for (var i = 0; i < this.canvas.length / this.w; i += 1) {
+			chunks.push(this.canvas.slice(this.w * i, this.w * (i + 1)).join(''));
+		}
+		return chunks.join('\n').replace(/\t/g, '');
+	};
+
 	// # 1マス書く
 	// @arg: {
 	//    x: 'x座標'


### PR DESCRIPTION
**ちゃんと動いてないのでフォーク元には投げられない。**

## 問題と症状

[ANSI escape code](https://en.wikipedia.org/wiki/ANSI_escape_code) を出力する場合、表示上の文字幅よりバイナリの数が大きくなり、その際に崩れてしまう。

![image](https://user-images.githubusercontent.com/648041/29483568-ff429f68-84e3-11e7-9afa-eb8840fd022e.png)

## 改修失敗内容

set で更新する限りは大丈夫そうだけど、drawText を使うと対応できてない。

set の場合:
```
> var cc = new CharCanvas(20, 5, '-');
undefined
> cc.set(5, 2, '\u001b[31mA\u001b[39m');
undefined
> cc.print()
--------------------
--------------------
-----A----
--------------------
--------------------
undefined
> console.log(cc.toStringZ());
--------------------
--------------------
-----A--------------
--------------------
--------------------
undefined
```

drawText の場合:
```
> var cc = new CharCanvas(20, 5, '-');
undefined
> cc.drawText(5, 2, '\u001b[31mA\u001b[39m');
undefined
> cc.print()
--------------------
--------------------
-----A----
--------------------
--------------------
undefined
> console.log(cc.toStringZ());
--------------------
--------------------
-----A----
--------------------
--------------------
undefined
```

drawText が 1 文字 = 1 byte として解釈して canvas に入れているから。
ちゃんと ANSI escape code を解釈するには専用のライブラリが必要になるので、話が大きくなりすぎるので NG。

とりあえず、set を使って 1 文字ずつ更新すれば大丈夫そう。